### PR TITLE
fix: update version to match with release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "asak"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asak"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 keywords = ["audio", "music", "DSP", "synth", "synthesizer"]
 readme = "README.md"


### PR DESCRIPTION
👋 seeing version mismatch while doing [0.3.5 release build,](https://github.com/Homebrew/homebrew-core/pull/202645), thus patching the version number.

cc @chaosprint 